### PR TITLE
Updated utility timeslot function to use timeSlotId instead of movieId

### DIFF
--- a/OnlineMovieReservationSystem/src/com/aws/JavaG1/Screens.java
+++ b/OnlineMovieReservationSystem/src/com/aws/JavaG1/Screens.java
@@ -132,7 +132,6 @@ public class Screens {
                     break;
             }
         }
-        scanner.close();
     }
 
     private static byte Screen3AMenu() {

--- a/OnlineMovieReservationSystem/src/com/aws/JavaG1/utilities/Utility.java
+++ b/OnlineMovieReservationSystem/src/com/aws/JavaG1/utilities/Utility.java
@@ -39,7 +39,7 @@ public class Utility {
 
     public static Timeslot getTimeSlotById(ArrayList<Timeslot> timeslots, int timeslotID){
         for(Timeslot timeslot: timeslots){
-            if(timeslot.getMovieID() == timeslotID)
+            if(timeslot.getTimeSlotID() == timeslotID)
                 return timeslot;
         }
         return null;


### PR DESCRIPTION
In Utility.getTimeSlotById() instead of getMovieId change to getTimeSlotId

#4 